### PR TITLE
fix/chapter-11-safeclib

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,6 +14,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends automake libtool autoconf
+    - name: Install safeclib
+      run: sudo ./chapter-11/install-safeclib.sh
     - name: configure
       run: ./configure
     - name: make

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 chapter-6/caesar
 chapter-10/bin/*
 dist/
+safeclib*/
+safeclib*.tar.gz

--- a/chapter-11/README.md
+++ b/chapter-11/README.md
@@ -1,0 +1,51 @@
+# Chapter 11
+
+## Overview
+
+Several features in this chapter rely on the
+`C11 Annex K Bounds-Checking Interfaces`. However, support for `Annex K` is
+limited in many compilers, such as `gcc` and `clang`. The presence of `Annex K`
+support can be verified using the `__STDC_LIB_EXT1__` macro
+([error-handling][error-handling]).
+
+To address this limitation, the [safeclib library][safeclib] can be utilized, as
+it provides an implementation of these interfaces.
+
+## Safeclib Library
+
+### Manual Installation
+
+Refer to the [safeclib GitHub repository][safeclib] for detailed installation
+instructions.
+
+### Installation Script
+
+For convenience, the installation of `safeclib` can be facilitated using the
+provided script [install-safeclib.sh](./install-safeclib.sh). This script is
+intended for demonstration purposes.
+
+Ensure the following tools are installed:
+
+- libtool
+- autoconf
+- automake
+
+To use the installation script, execute the following commands:
+
+```sh
+sudo ./install-safeclib.sh
+```
+
+## Build and Run a Program
+
+To build a program, link the `safeclib` library.
+
+For example:
+
+```sh
+cc -o my_program source.c -lsafec
+./my_program
+```
+
+[safeclib]: https://github.com/rurban/safeclib
+[error-handling]: https://en.cppreference.com/w/c/error

--- a/chapter-11/error.c
+++ b/chapter-11/error.c
@@ -1,12 +1,18 @@
+
+// Checks if bounds-checking interfaces are supported.
+#ifdef __STDC_LIB_EXT1__
 #define __STDC_WANT_LIB_EXT1__ 1
+#else
+#include <safeclib/safe_mem_lib.h>
+#include <safeclib/safe_str_lib.h>
+#include <safeclib/safe_lib.h>
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <malloc.h>
-#include "safe_mem_lib.h"
-#include "safe_str_lib.h" 
-#include "safe_lib.h" 
 
 errno_t print_error(errno_t errnum) {
   rsize_t size = strerrorlen_s(errnum);

--- a/chapter-11/install-safeclib.sh
+++ b/chapter-11/install-safeclib.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+# Safeclib version.
+SAFECLIB_VERSION="3.7.1"
+
+# Check if a command exists.
+check_command() {
+  if ! command -v "$1" &>/dev/null; then
+    echo "Error: $1 is not installed." >&2
+    exit 1
+  fi
+}
+
+# Download and extract safeclib.
+download() {
+  local package="safeclib-${SAFECLIB_VERSION}.tar.gz"
+  local url="https://github.com/rurban/safeclib/releases/download/v${SAFECLIB_VERSION}/${package}"
+
+  echo "Downloading safeclib ${SAFECLIB_VERSION}..."
+  curl -fsSLO "${url}"
+  tar -xf "${package}"
+
+  rm "${package}"
+}
+
+# Build and install safeclib.
+build_and_install() {
+  local directory="safeclib-${SAFECLIB_VERSION}"
+
+  pushd "${directory}"
+
+  echo "Building and installing safeclib..."
+  autoreconf -Wall --install && ./configure && make
+  make install
+
+  popd
+}
+
+# Update config.
+update_config() {
+  echo "Updating config..."
+  ldconfig
+}
+
+# Clean up.
+cleanup() {
+  echo "Cleaning up..."
+  find . -maxdepth 1 -type d -name "safeclib-*" -exec rm -rf {} \;
+}
+
+# Main function.
+main() {
+  # Check if required commands are installed.
+  check_command curl
+  check_command tar
+  check_command autoreconf
+  check_command ldconfig
+  check_command automake
+
+  # Build and install safeclib.
+  download
+  build_and_install
+  update_config
+  cleanup
+
+  echo "safeclib ${SAFECLIB_VERSION} installed successfully"
+}
+
+main "$@"

--- a/makefile
+++ b/makefile
@@ -1,15 +1,26 @@
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-SOURCES = $(wildcard chapter-[1-9]/*.c chapter-11/*.c)
+SOURCES = $(wildcard chapter-[1-9]/*.c)
+SOURCES_CHAPTER_11 = $(wildcard chapter-11/*.c)
 NAMES = $(basename $(SOURCES))
+NAMES_CHAPTER_11 = $(basename $(SOURCES_CHAPTER_11))
 DIRS = $(wildcard ./chapter-*/)
 DIST = $(subst ./,dist/,$(DIRS))
 DATA = chapter-8/signals.txt
+ANNEX_K_SUPPORTED := $(shell cc -dM -E - </dev/null | grep -c __STDC_LIB_EXT1__)
 
-all: $(DIST) $(NAMES)
+all: $(DIST) $(NAMES) $(NAMES_CHAPTER_11)
+
 $(NAMES): $(SOURCES)
 	cc $@.c -o dist/$@
+
+$(NAMES_CHAPTER_11): $(SOURCES_CHAPTER_11)
+ifeq ($(ANNEX_K_SUPPORTED),1)
+	cc $@.c -o dist/$@
+else
+	cc $@.c -o dist/$@ -lsafec
+endif
 
 $(DIST): $(DIRS)
 	mkdir -p $@


### PR DESCRIPTION
# Description

## Purpose

This PR addresses the prevalent issue of missing C11 Annex K Bounds-Checking interfaces in various compilers.

## Key Changes

- **Safeclib Integration:** Added a script for building and installing the [safeclib](https://github.com/rurban/safeclib) library, offering a robust alternative to native Annex K support.
- **Codebase Update:** Modified the examples in Chapter 11 to utilize the [`__STDC_LIB_EXT1__`](https://en.cppreference.com/w/c/error) macro for detecting and using native Annex K functions when available. In their absence, we fall back to `safeclib`.
- **Makefile Update:** Updated the Makefile to conditionally link `safeclib` to Chapter 11 examples if the `__STDC_LIB_EXT1__` macro is not defined.

## Impact

- **Cross-Compiler Compatibility:** These changes make the project more flexible, catering to compilers that do not natively support C11 Annex K interfaces.

## Testing

- Conducted rigorous local testing to validate the changes.
- Updated the CI workflow to include tests covering the new setup.
